### PR TITLE
(#25) Convert to .Net 2.1

### DIFF
--- a/src/NCI.OCPL.Api.BestBets/Controllers/BestBetsController.cs
+++ b/src/NCI.OCPL.Api.BestBets/Controllers/BestBetsController.cs
@@ -14,6 +14,9 @@ using NCI.OCPL.Api.Common;
 
 namespace NCI.OCPL.Api.BestBets.Controllers
 {
+    /// <summary>
+    /// Controller for the /bestbets route.
+    /// </summary>
     [Route("[controller]")]
     public class BestBetsController : Controller
     {
@@ -22,6 +25,9 @@ namespace NCI.OCPL.Api.BestBets.Controllers
         private readonly IHealthCheckService _healthService;
         private readonly ILogger<BestBetsController> _logger;
 
+        /// <summary>
+        /// Status to return when the system is operating correctly.
+        /// </summary>
         public const string HEALTHY_STATUS = "alive!";
 
         /// <summary>

--- a/src/NCI.OCPL.Api.BestBets/Interfaces/IBestBetCategory.cs
+++ b/src/NCI.OCPL.Api.BestBets/Interfaces/IBestBetCategory.cs
@@ -16,7 +16,9 @@ namespace NCI.OCPL.Api.BestBets
         /// <returns></returns>
         string Language { get; }
 
-        //No clue what this is...
+        /// <summary>
+        ///No clue what this is...
+        /// </summary>
         bool Display { get; }
 
         /// <summary>

--- a/src/NCI.OCPL.Api.BestBets/Models/BestBetsCategoryDisplay.cs
+++ b/src/NCI.OCPL.Api.BestBets/Models/BestBetsCategoryDisplay.cs
@@ -3,6 +3,9 @@ using Nest;
 
 namespace NCI.OCPL.Api.BestBets
 {
+    /// <summary>
+    /// Represents Display information about a Best Bet
+    /// </summary>
     [ElasticsearchType(Name = "categorydisplay")]
     public class BestBetsCategoryDisplay : IBestBetDisplay
     {
@@ -30,6 +33,9 @@ namespace NCI.OCPL.Api.BestBets
         [Text(Name = "weight")]
         public int Weight { get; set; }
 
+        /// <summary>
+        /// Default constructor.
+        /// </summary>
         public BestBetsCategoryDisplay() { }
     }
 }

--- a/src/NCI.OCPL.Api.BestBets/NCI.OCPL.Api.BestBets.csproj
+++ b/src/NCI.OCPL.Api.BestBets/NCI.OCPL.Api.BestBets.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <DebugType>portable</DebugType>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssemblyName>NCI.OCPL.Api.BestBets</AssemblyName>

--- a/src/NCI.OCPL.Api.BestBets/Program.cs
+++ b/src/NCI.OCPL.Api.BestBets/Program.cs
@@ -9,13 +9,25 @@ using Microsoft.Extensions.Configuration;
 
 namespace NCI.OCPL.Api.BestBets
 {
+    /// <summary>
+    /// Host application for BestBets.
+    /// </summary>
     public class Program
     {
+        /// <summary>
+        /// The main, where it all begins.
+        /// </summary>
+        /// <param name="args"></param>
         public static void Main(string[] args)
         {
             BuildWebHost(args).Run();
         }
 
+        /// <summary>
+        /// Builds a host for the web application
+        /// </summary>
+        /// <param name="args"></param>
+        /// <returns></returns>
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()

--- a/src/NCI.OCPL.Api.BestBets/Services/ESBestBetsMatchService.cs
+++ b/src/NCI.OCPL.Api.BestBets/Services/ESBestBetsMatchService.cs
@@ -197,7 +197,7 @@ namespace NCI.OCPL.Api.BestBets.Services
         /// <param name="cleanedTerm">The Cleaned Term</param>
         /// <param name="language">The language of the best bets to fetch</param>
         /// <param name="numTokens">The number of tokens an analyzer would break this up into</param>
-        /// <returns>IEnumerable<BestBetsMatch> suitable for iterating through</returns>
+        /// <returns>IEnumerable&lt;BestBetsMatch&gt; suitable for iterating through</returns>
         private async Task<IEnumerable<BestBetsMatch>> GetBestBetMatchesAsync(string collection, string cleanedTerm, string language, int numTokens)
         {
             //Pool up all the fetches to be called in one shot
@@ -211,7 +211,7 @@ namespace NCI.OCPL.Api.BestBets.Services
 
                 return results.SelectMany(i => i);
             }
-            catch (Exception ex)
+            catch (Exception)
             {
                 throw;
             }

--- a/src/NCI.OCPL.Api.Common.Testing/NCI.OCPL.Api.Common.Testing.csproj
+++ b/src/NCI.OCPL.Api.Common.Testing/NCI.OCPL.Api.Common.Testing.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/NCI.OCPL.Api.Common/NCI.OCPL.Api.Common.csproj
+++ b/src/NCI.OCPL.Api.Common/NCI.OCPL.Api.Common.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <DebugType>portable</DebugType>
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <AssetTargetFallback>$(PackageTargetFallback);dotnet5.6;portable-net45+win8</AssetTargetFallback>
@@ -11,7 +11,7 @@
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
     <PackageReference Include="NEST" Version="5.6.1" />
     <PackageReference Include="NSwag.AspNetCore" Version="11.17.1" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/NCI.OCPL.Api.BestBets.Tests/NCI.OCPL.Api.BestBets.Tests.csproj
+++ b/test/NCI.OCPL.Api.BestBets.Tests/NCI.OCPL.Api.BestBets.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>NCI.OCPL.Api.BestBets.Tests</AssemblyName>
     <PackageId>NCI.OCPL.Api.BestBets.Tests</PackageId>
@@ -26,7 +26,7 @@
     <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="3.3.0" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.4" />
     <PackageReference Include="coverlet.msbuild" Version="1.1.1" />
   </ItemGroup>
 


### PR DESCRIPTION
- Change targeted framework from 2.0 to 2.1.
- Replace Microsoft.AspNetCore.All with Microsoft.AspNetCore.App
- Clean up most extraneous warning messages.