### PR TITLE
(#28) Allow for searches with accents

### DIFF
--- a/src/NCI.OCPL.Api.BestBets/web.config
+++ b/src/NCI.OCPL.Api.BestBets/web.config
@@ -6,7 +6,7 @@
     </handlers>
     <aspNetCore processPath="%LAUNCHER_PATH%" arguments="%LAUNCHER_ARGS%" stdoutLogEnabled="false" stdoutLogFile=".\logs\stdout" forwardWindowsAuthToken="false"/>
 	<security>
-      <requestFiltering>
+      <requestFiltering allowHighBitCharacters="true">
         <fileExtensions allowUnlisted="true" />
       </requestFiltering>
     </security>


### PR DESCRIPTION
* Update web.config to allow for high-bit characters in search strings
* Closes #28