### PR TITLE
(#36) Add CI build workflow.

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -1,0 +1,207 @@
+name: Main workflow
+on:
+  ## This tries to avoid unessesary pushes to forked repo
+  ## development branches. No sense in a dev building every
+  ## time they push for a PR and no one should be working on
+  ## common branches in their fork.
+  push:
+    branches:
+      - master
+      - develop
+      - 'hotfix/**'
+      - 'release/**'
+      - 'feature/**'
+  ## Any pull request. Yes the syntax looks weird
+  pull_request:
+jobs:
+
+  extract_build_info:
+    ## Gather metadata for the build artifact.
+    ##
+    ## This is done in a separate job so we don't have to figure out how to extract the
+    ## same information on every platform.
+    ## Ideally, this should be done in a GitHub Action.
+    name: Extract build metadata.
+    runs-on: ubuntu-latest
+    outputs:
+      build_name: ${{ steps.set_outputs.outputs.build_name }}
+      branch_name: ${{ steps.set_outputs.outputs.branch_name }}
+      commit_hash: ${{ steps.set_outputs.outputs.commit_hash }}
+      repo_owner: ${{ steps.set_outputs.outputs.repo_owner }}
+      repo_name: ${{ steps.set_outputs.outputs.repo_name }}
+
+    steps:
+      - name: Set outputs
+        id: set_outputs
+        run: |
+          ## PUSH
+          if [ "${{ github.event_name }}" == "push" ]; then
+            BUILD_NAME=$(sed -E 's/refs\/(heads|tags)\///; s/\//__/g;' <<< $GITHUB_REF)
+            BRANCH_NAME=$(sed -E 's/refs\/(heads|tags)\///;' <<< $GITHUB_REF)
+            COMMIT_HASH=$(echo "${GITHUB_SHA}")
+          ## PULL_REQUEST
+          elif [ "${{ github.event_name }}" == "pull_request" ]; then
+            BUILD_NAME=$(echo "pr-${{ github.event.pull_request.number }}")
+            BRANCH_NAME=$(echo "pr-${{ github.event.pull_request.number }}")
+            COMMIT_HASH=$(echo "${{ github.event.pull_request.head.sha }}")
+          else
+            ## ERROR
+            exit 1
+          fi
+          ## For step checks and artifact deployment path.
+          ## Same for push and PR
+          export REPO_FULL=${{ github.repository }}
+          export REPO_RE='([^/]+)/(.*)'
+          [[ "$REPO_FULL" =~ $REPO_RE ]]
+          REPO_OWNER=$(echo "${BASH_REMATCH[1]}")
+          REPO_NAME=$(echo "${BASH_REMATCH[2]}")
+          ## Set step outputs for later use
+          echo ::set-output name=build_name::${BUILD_NAME}
+          echo ::set-output name=branch_name::${BRANCH_NAME}
+          echo ::set-output name=commit_hash::${COMMIT_HASH}
+          echo ::set-output name=repo_owner::${REPO_OWNER}
+          echo ::set-output name=repo_name::${REPO_NAME}
+
+  test_build_release:
+    name: Test, Build, Publish on OS ${{ matrix.operating-system }}
+    needs: extract_build_info
+    runs-on: ${{ matrix.operating-system }}
+    strategy:
+      matrix:
+        operating-system: [ubuntu-latest, windows-latest, macOS-latest]
+    steps:
+      - uses: actions/checkout@master
+        ## using latest LTS releases - also it MUST be the SDK version,
+        ## which have stupidly high numbers for the patch version.
+        ## '3.1.100' breaks our app, so let's just use 2.x
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '2.1.607'
+      - name: Build with dotnet
+        run: dotnet build --configuration Release /WarnAsError
+      - name: Unit Tests (with Coverage)
+        run: |
+              if [ "$RUNNER_OS" == "Windows" ]; then
+                dotnet test
+              else
+                dotnet test /p:CollectCoverage=true /p:CoverletOutputFormat=lcov /p:CoverletOutput=../../lcov test/**
+              fi
+        shell: bash
+      - name: Save Code Coverage Output
+        uses: actions/upload-artifact@v1
+        with:
+          name: coverage-${{ matrix.operating-system }}
+          path: lcov.info
+        if: matrix.operating-system != 'windows-latest'
+      - name: Publish
+        run: dotnet publish -c Release -o $GITHUB_WORKSPACE/out src/NCI.OCPL.Api.BestBets/
+        shell: bash
+      - name: Record metadata
+        env:
+          BUILD_INFO: ${{ toJson( needs.extract_build_info.outputs ) }}
+        run: |
+          echo "$BUILD_INFO"
+          mkdir $GITHUB_WORKSPACE/out/wwwroot/
+          echo "$BUILD_INFO" > $GITHUB_WORKSPACE/out/wwwroot/build-info.json
+        shell: bash
+      - name: Upload Published Artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: bestbets-api-${{ matrix.operating-system }}
+          path: out
+
+  integration_tests:
+    name: Run Integration Tests (on Linux)
+    runs-on: ubuntu-latest
+    needs: test_build_release
+    services:
+      elasticsearch:
+        image: elasticsearch:5.6.16
+        ports:
+          ## NOTE: This will be exposed as a random port referenced below by job.services.elasticsearch.ports[9200]
+          - 9200/tcp
+        options: --health-cmd="curl http://localhost:9200/_cluster/health" --health-interval=10s --health-timeout=5s --health-retries=10
+
+    steps:
+      - uses: actions/checkout@master
+      - name: Download Published Artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: bestbets-api-ubuntu-latest
+          path: built-api
+        ## using latest LTS releases - also it MUST be the SDK version,
+        ## which have stupidly high numbers for the patch version.
+        ## '3.1.100' breaks our app, so let's just use 2.x
+      - name: Setup dotnet
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: '2.1.607'
+      - name: Load Data into elasticsearch & prepare for tests
+        env:
+          ELASTIC_SEARCH_HOST: http://localhost:${{ job.services.elasticsearch.ports[9200] }}
+        run: |
+              ## Create test output and API logging location
+              mkdir -p integration-tests/target
+
+#              ## Load the elasticsearch data
+#              ./integration-tests/bin/load-integration-data.sh
+      - name: Start API
+        env:
+          Elasticsearch__Servers: http://localhost:${{ job.services.elasticsearch.ports[9200] }}
+          ASPNETCORE_LOGGING__CONSOLE__DISABLECOLORS: true
+          API_URL: http://localhost:5000
+          SLEEP_TIMEOUT: 5
+          WAIT_DURATION: 120
+          APP_PATH: ./built-api
+          APP_ASSEMBLY: NCI.OCPL.Api.BestBets.dll
+        run: |
+              ## TODO: This should become a GitHub Action.
+
+              ## Start the app and log output
+              ## NOTE: We must change directory because while you can call `dotnet "${APP_PATH}/${APP_ASSEMBLY}"`
+              ## it will not find the appsettings.json, so we must cd into the APP_PATH first
+              cd $APP_PATH && dotnet $APP_ASSEMBLY > ../integration-tests/target/api_log.txt 2>&1 &
+
+              time_waited=1
+              echo "Checking status of ${API_URL}."
+              until $(curl --output /dev/null --silent --fail ${API_URL}); do
+                echo $?
+
+                if [ $time_waited -ge $WAIT_DURATION ]; then
+                    echo "Waited past duration. Exiting"
+                    exit 1
+                fi
+
+                sleep $SLEEP_TIMEOUT
+                time_waited=$((time_waited + SLEEP_TIMEOUT))
+              done
+
+              echo "API is up"
+#      - name: Run Integration Test
+#        ## Normally bash runs with -e which exits the shell upon hitting
+#        ## an error which breaks our capturing of those errors.
+#        shell: bash --noprofile --norc -o pipefail {0}
+#        run: |
+#              ## Run Karate
+#              cd integration-tests && ./bin/karate ./features
+#
+#              ## Store the exit code off so we can pass this step and
+#              ## capture the test output in the next step, but still
+#              ## fail the entire job
+#              echo ::set-env name=TEST_EXIT_CODE::$?
+#              exit 0
+#      - name: Upload Integration test results
+#        uses: actions/upload-artifact@v1
+#        with:
+#          name: integration-test-results
+#          path: integration-tests/target
+#      - name: Fail build on bad tests
+#        run: |
+#              ## Check if we had errors on the test step, and if so, fail the job
+#              if [ $TEST_EXIT_CODE -ne 0 ]; then
+#                echo "Tests Failed -- See Run Integration Test step or integration-test-results artifact for more information"
+#                exit $TEST_EXIT_CODE
+#              else
+#                echo "Tests passed"
+#              fi

--- a/src/NCI.OCPL.Api.Common/NCI.OCPL.Api.Common.csproj
+++ b/src/NCI.OCPL.Api.Common/NCI.OCPL.Api.Common.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
     <PackageReference Include="NEST" Version="5.6.1" />
     <PackageReference Include="NSwag.AspNetCore" Version="11.17.1" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.4" />
+    <PackageReference AllowExplicitVersion="True" Include="Microsoft.AspNetCore.App" Version="2.1.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/NCI.OCPL.Api.BestBets.Tests/NCI.OCPL.Api.BestBets.Tests.csproj
+++ b/test/NCI.OCPL.Api.BestBets.Tests/NCI.OCPL.Api.BestBets.Tests.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Moq" Version="4.8.2" />
     <PackageReference Include="RichardSzalay.MockHttp" Version="3.3.0" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.App" Version="2.1.4" />
+    <PackageReference AllowExplicitVersion="True" Include="Microsoft.AspNetCore.App" Version="2.1.4" />
     <PackageReference Include="coverlet.msbuild" Version="1.1.1" />
   </ItemGroup>
 


### PR DESCRIPTION
- Adds CI workflow.
- Change Microsoft.AspNetCore.App package reference to allow a clean build.
- Adds stubbed-out integration tests to be built out in a separate story.

Close #36 