### PR TITLE
(#42) Remove set-env command from integration tests.

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -192,7 +192,7 @@ jobs:
               ## Store the exit code off so we can pass this step and
               ## capture the test output in the next step, but still
               ## fail the entire job
-              echo ::set-env name=TEST_EXIT_CODE::$?
+              echo "TEST_EXIT_CODE=$?" >> $GITHUB_ENV
               exit 0
       - name: Upload Integration test results
         uses: actions/upload-artifact@v1

--- a/test/NCI.OCPL.Api.BestBets.Tests/NCI.OCPL.Api.BestBets.Tests.csproj
+++ b/test/NCI.OCPL.Api.BestBets.Tests/NCI.OCPL.Api.BestBets.Tests.csproj
@@ -16,7 +16,8 @@
 
   <ItemGroup>
     <ProjectReference Include="../../src/NCI.OCPL.Api.BestBets/NCI.OCPL.Api.BestBets.csproj" />
-    <ProjectReference Include="..\..\src\NCI.OCPL.Api.Common.Testing\NCI.OCPL.Api.Common.Testing.csproj" />
+    <ProjectReference Include="../../src/NCI.OCPL.Api.Common/NCI.OCPL.Api.Common.csproj" />
+    <ProjectReference Include="../../src/NCI.OCPL.Api.Common.Testing/NCI.OCPL.Api.Common.Testing.csproj" />
   </ItemGroup>
 
   <ItemGroup>
@@ -27,7 +28,10 @@
     <PackageReference Include="RichardSzalay.MockHttp" Version="3.3.0" />
     <PackageReference Include="System.Xml.XmlSerializer" Version="4.3.0" />
     <PackageReference AllowExplicitVersion="True" Include="Microsoft.AspNetCore.App" Version="2.1.4" />
-    <PackageReference Include="coverlet.msbuild" Version="1.1.1" />
+    <PackageReference Include="coverlet.msbuild" Version="2.8.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Pass TEST_EXIT_CODE value between steps via environment file.

Close #42 