### PR TITLE
(#62, #63) Bump NSwag.AspNetCore to v13.20

### DIFF
--- a/src/NCI.OCPL.Api.BestBets/NCI.OCPL.Api.BestBets.csproj
+++ b/src/NCI.OCPL.Api.BestBets/NCI.OCPL.Api.BestBets.csproj
@@ -7,7 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="NCI.OCPL.Api.Common" Version="2.*" />
-    <PackageReference Include="NSwag.AspNetCore" Version="13.11.*" />
+    <PackageReference Include="NSwag.AspNetCore" Version="13.20.*" />
     <PackageReference Include="NEST" Version="7.9.*" />
   </ItemGroup>
 </Project>

--- a/src/NCI.OCPL.Api.BestBets/Services/ESBestBetsDisplayService.cs
+++ b/src/NCI.OCPL.Api.BestBets/Services/ESBestBetsDisplayService.cs
@@ -76,8 +76,8 @@ namespace NCI.OCPL.Api.BestBets.Services
                 }
                 catch (Exception ex)
                 {
-                    _logger.LogError("Could not fetch category ID " + categoryID, ex);
-                    throw new APIErrorException(500, "Could not fetch category ID " + categoryID);
+                    _logger.LogError(ex, $"Could not fetch category ID {categoryID}");
+                    throw new APIErrorException(500, $"Could not fetch category ID {categoryID}");
                 }
 
                 // If the API's response isn't valid, throw an error and return 500 status code.


### PR DESCRIPTION
Fix parameter order when logging exceptions.

Closes #62
Closes #63


Testing needs:
- Standard regression tests
- Verify navigating to https://webapis-dev.cancer.gov/bestbets/v1/index.html?configUrl=https://jumpy-floor.surge.sh/test.json displays the best bets Swagger page.
